### PR TITLE
fixed ios generateThumbnail issue

### DIFF
--- a/android/src/main/kotlin/com/example/easy_video_editor/handler/GenerateThumbnailCommand.kt
+++ b/android/src/main/kotlin/com/example/easy_video_editor/handler/GenerateThumbnailCommand.kt
@@ -21,6 +21,7 @@ class GenerateThumbnailCommand(private val context: Context) : Command {
         val width = call.argument<Number>("width")?.toInt()
         val height = call.argument<Number>("height")?.toInt()
         val quality = call.argument<Number>("quality")?.toInt() ?: 80
+        val exactFrame = call.argument<Boolean>("exactFrame") ?: false
 
         if (videoPath == null || position == null) {
             result.error(
@@ -46,6 +47,7 @@ class GenerateThumbnailCommand(private val context: Context) : Command {
                     positionMs = position,
                     width = width,
                     height = height,
+                    exactFrame = exactFrame,
                     quality = quality
                 )
                 result.success(outputPath)

--- a/android/src/main/kotlin/com/example/easy_video_editor/utils/VideoUtils.kt
+++ b/android/src/main/kotlin/com/example/easy_video_editor/utils/VideoUtils.kt
@@ -897,16 +897,8 @@ class VideoUtils {
             return@withContext try {
                 // ── choose best method to obtain (possibly pre-scaled) Bitmap ─────────
                 val bitmap: Bitmap = when {
-                    // ── ONE dimension given & API 29+ → ThumbnailUtils (keeps aspect)
-                    Build.VERSION.SDK_INT >= 29 && (width == null || height == null) -> {
-                        val box = if (width != null) Size(width, width)
-                                else Size(height!!, height)
-                        ThumbnailUtils.createVideoThumbnail(File(videoPath), box, null)
-                            ?: throw VideoException("Failed to generate thumbnail")
-                    }
-
-                    // ── ONE dimension given & API 27–28 → getScaledFrameAtTime (keeps aspect)
-                    Build.VERSION.SDK_INT in 27..28 && (width == null || height == null) -> {
+                    // API 27+  and  at least ONE dimension ⇒ let retriever scale for us
+                    Build.VERSION.SDK_INT >= 27 && (width == null || height == null) -> {
                         val primary = width ?: height!!
                         val secondary = Int.MAX_VALUE          // so only 'primary' is respected
                         val retriever = MediaMetadataRetriever().apply { setDataSource(videoPath) }

--- a/android/src/main/kotlin/com/example/easy_video_editor/utils/VideoUtils.kt
+++ b/android/src/main/kotlin/com/example/easy_video_editor/utils/VideoUtils.kt
@@ -898,7 +898,7 @@ class VideoUtils {
                 // ── choose best method to obtain (possibly pre-scaled) Bitmap ─────────
                 val bitmap: Bitmap = when {
                     // API 27+  and  at least ONE dimension ⇒ let retriever scale for us
-                    Build.VERSION.SDK_INT >= 27 && (width == null || height == null) -> {
+                    Build.VERSION.SDK_INT >= 27 && (width != null || height != null) -> {
                         val primary = width ?: height!!
                         val secondary = Int.MAX_VALUE          // so only 'primary' is respected
                         val retriever = MediaMetadataRetriever().apply { setDataSource(videoPath) }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -55,15 +55,15 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.1.2"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   file:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -266,18 +266,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   webdriver:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "3d773670966f02a646319410766d3b5e1037efb7f07cc68f844d5e06cd4d61c8"
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.4"
+    version: "3.1.0"
 sdks:
   dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/ios/Classes/handler/GenerateThumbnailCommand.swift
+++ b/ios/Classes/handler/GenerateThumbnailCommand.swift
@@ -18,6 +18,12 @@ class GenerateThumbnailCommand: Command {
 
         let width  = (arguments["width"]  as? NSNumber)?.intValue
         let height = (arguments["height"] as? NSNumber)?.intValue        
+
+        let exactFrame: Bool = {
+            if let b = arguments["exactFrame"] as? Bool { return b }
+            if let n = arguments["exactFrame"] as? NSNumber { return n.boolValue }
+            return false
+        }()        
         
         let operationId = OperationManager.shared.generateOperationId()
         
@@ -36,6 +42,7 @@ class GenerateThumbnailCommand: Command {
                     width: width,
                     height: height,
                     quality: quality.intValue,
+                    exactFrame: exactFrame,
                     workItem: workItem
                 )
 

--- a/ios/Classes/handler/GenerateThumbnailCommand.swift
+++ b/ios/Classes/handler/GenerateThumbnailCommand.swift
@@ -15,6 +15,9 @@ class GenerateThumbnailCommand: Command {
             ))
             return
         }
+
+        let width  = (arguments["width"]  as? NSNumber)?.intValue
+        let height = (arguments["height"] as? NSNumber)?.intValue        
         
         let operationId = OperationManager.shared.generateOperationId()
         
@@ -30,6 +33,8 @@ class GenerateThumbnailCommand: Command {
                 let outputPath = try VideoUtils.generateThumbnail(
                     videoPath: videoPath,
                     positionMs: positionMs.int64Value,
+                    width: width,
+                    height: height,
                     quality: quality.intValue,
                     workItem: workItem
                 )

--- a/ios/Classes/utils/VideoUtils.swift
+++ b/ios/Classes/utils/VideoUtils.swift
@@ -764,9 +764,9 @@ class VideoUtils {
             case let (w?, h?):
                 generator.maximumSize = CGSize(width: w, height: h)      // both → bounding box
             case let (w?, nil):
-                generator.maximumSize = CGSize(width: CGFloat(w), height: CGFloat.greatestFiniteMagnitude) // width only
+                generator.maximumSize = CGSize(width: CGFloat(w), height: 0.0) // width only
             case let (nil, h?):
-                generator.maximumSize = CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat(h)) // height only
+                generator.maximumSize = CGSize(width: 0.0, height: CGFloat(h)) // height only
             default: break
             }
         }        

--- a/lib/src/builder/video_editor_builder.dart
+++ b/lib/src/builder/video_editor_builder.dart
@@ -296,6 +296,7 @@ class VideoEditorBuilder {
     required int quality,
     int? height,
     int? width,
+    bool exactFrame = false,
     String? outputPath,
   }) async {
     final result = await _editor.generateThumbnail(
@@ -304,6 +305,7 @@ class VideoEditorBuilder {
       quality,
       height: height,
       width: width,
+      exactFrame: exactFrame,
     );
 
     if (result != null && outputPath != null) {

--- a/lib/src/easy_video_editor.dart
+++ b/lib/src/easy_video_editor.dart
@@ -55,10 +55,10 @@ class EasyVideoEditor {
   /// [width] optional width of the thumbnail in pixels.
   Future<String?> generateThumbnail(
       String videoPath, int positionMs, int quality,
-      {int? height, int? width}) {
+      {int? height, int? width, exactFrame = false}) {
     return EasyVideoEditorPlatform.instance.generateThumbnail(
         videoPath, positionMs, quality,
-        height: height, width: width);
+        height: height, width: width, exactFrame: exactFrame);
   }
 
   /// Compresses a video by adjusting its resolution and bitrate.

--- a/lib/src/platform/easy_video_editor_method_channel.dart
+++ b/lib/src/platform/easy_video_editor_method_channel.dart
@@ -82,12 +82,13 @@ class MethodChannelEasyVideoEditor extends EasyVideoEditorPlatform {
   @override
   Future<String?> generateThumbnail(
       String videoPath, int positionMs, int quality,
-      {int? height, int? width}) async {
+      {int? height, int? width, bool exactFrame = false}) async {
     final result =
         await methodChannel.invokeMethod<String>('generateThumbnail', {
       'videoPath': videoPath,
       'positionMs': positionMs,
       'quality': quality,
+      'exactFrame': exactFrame,
       if (height != null) 'height': height,
       if (width != null) 'width': width,
     });

--- a/lib/src/platform/easy_video_editor_platform_interface.dart
+++ b/lib/src/platform/easy_video_editor_platform_interface.dart
@@ -116,7 +116,7 @@ abstract class EasyVideoEditorPlatform extends PlatformInterface {
   /// Returns the path to the generated thumbnail, or null if the operation fails.
   Future<String?> generateThumbnail(
       String videoPath, int positionMs, int quality,
-      {int? height, int? width}) {
+      {int? height, int? width, bool exactFrame = false}) {
     throw UnimplementedError('generateThumbnail() has not been implemented.');
   }
 


### PR DESCRIPTION
- ios was ignoring width and height
- improved performance of ios and android by using the underlying video API scaling
- there is now no need to specify both width and height. If both specified you get exactly the given size and ignoring aspect ratio. If one is not specified, the other is calculated from the original aspect ratio.

closes #31 