### PR TITLE
fix(ios): add missing Foundation imports for SPM builds

### DIFF
--- a/ios/easy_video_editor/Sources/easy_video_editor/command/Command.swift
+++ b/ios/easy_video_editor/Sources/easy_video_editor/command/Command.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Flutter
 
 protocol Command {

--- a/ios/easy_video_editor/Sources/easy_video_editor/utils/OperationManager.swift
+++ b/ios/easy_video_editor/Sources/easy_video_editor/utils/OperationManager.swift
@@ -1,3 +1,4 @@
+import Foundation
 class OperationManager {
     static let shared = OperationManager()
     

--- a/ios/easy_video_editor/Sources/easy_video_editor/utils/ProgressManager.swift
+++ b/ios/easy_video_editor/Sources/easy_video_editor/utils/ProgressManager.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Flutter
 
 // TEMPORARY: Will be removed when ProgressManager.swift is properly added to the Xcode project


### PR DESCRIPTION
OperationManager.swift, ProgressManager.swift, and Command.swift lack an explicit Foundation import. CocoaPods builds tolerated this via implicit/umbrella imports, but Swift Package Manager compiles the files strictly and fails with errors like 'Cannot find type DispatchWorkItem in scope'. The CancelOperationCommand errors seen alongside are a cascade of OperationManager failing to compile.

Fixes iawtk2302/easy_video_editor#43 (same 3-file fix verified in the issue thread against a release archive).