### PR TITLE
fix: use unique thumbnail temporary file names

### DIFF
--- a/android/src/main/kotlin/com/example/easy_video_editor/utils/VideoUtils.kt
+++ b/android/src/main/kotlin/com/example/easy_video_editor/utils/VideoUtils.kt
@@ -1002,7 +1002,7 @@ class VideoUtils {
                     else -> bitmap   // no resize needed
                 }
 
-                val outputFile = File(context.cacheDir, "thumbnail_${System.currentTimeMillis()}.jpg").apply {
+                val outputFile = File(context.cacheDir, "thumbnail_${UUID.randomUUID()}.jpg").apply {
                     if (exists()) delete()
                 }
 

--- a/ios/easy_video_editor/Sources/easy_video_editor/utils/VideoUtils.swift
+++ b/ios/easy_video_editor/Sources/easy_video_editor/utils/VideoUtils.swift
@@ -862,7 +862,8 @@ class VideoUtils {
             let imageRef = try generator.copyCGImage(at: time, actualTime: &actual)
             var image = UIImage(cgImage: imageRef)
             
-            let outputURL = FileManager.default.temporaryDirectory.appendingPathComponent("thumbnail_\(Date().timeIntervalSince1970).jpg")
+            let outputURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("thumbnail_\(UUID().uuidString).jpg")
             
             guard let data = image.jpegData(compressionQuality: CGFloat(quality) / 100),
                   (try? data.write(to: outputURL)) != nil else {


### PR DESCRIPTION
## Summary

Fixes concurrent `generateThumbnail()` calls sharing a timestamp-based intermediate JPEG name.

- use `UUID().uuidString` for iOS thumbnail temporary files
- use `UUID.randomUUID()` for Android thumbnail temporary files

Each native invocation now owns its temporary file, so copying and deleting the result for one request cannot affect another request.

## Verification

- Confirmed both platforms already import the UUID types used by this change.
- Ran `git diff --check`.

Fixes #45