### PR TITLE
fix(ios): re-encode trimmed video so the cut starts on a keyframe

### DIFF
--- a/ios/easy_video_editor/Sources/easy_video_editor/utils/VideoUtils.swift
+++ b/ios/easy_video_editor/Sources/easy_video_editor/utils/VideoUtils.swift
@@ -94,6 +94,26 @@ class VideoUtils {
         exportSession.outputURL = outputURL
         exportSession.outputFileType = .mp4
         exportSession.timeRange = timeRange
+
+        // Force a re-encode of the video track.
+        //
+        // Without a videoComposition the export takes the passthrough path
+        // and copies the source's compressed samples verbatim. A timeRange
+        // that does not start on a sync sample then yields a file whose
+        // opening frames reference a keyframe that is not in it, and whose
+        // first sync sample sits wherever the next source keyframe fell.
+        // Such a file decodes correctly front to back, so the damage is
+        // easy to miss - but it cannot be seeked back to its own start:
+        // players snap forward to that first sync sample instead, and a
+        // looping player shows only the tail of the clip. How far in that
+        // lands depends on the source GOP length.
+        //
+        // Guarded because trimVideo accepts audio-only assets, for which
+        // AVVideoComposition(propertiesOf:) has no track to size itself
+        // from and the export would fail.
+        if !asset.tracks(withMediaType: .video).isEmpty {
+            exportSession.videoComposition = AVVideoComposition(propertiesOf: asset)
+        }
         
         // Export with cancellation support
         try exportWithCancellation(exportSession: exportSession, workItem: workItem)


### PR DESCRIPTION
trimVideo sets a timeRange on an AVAssetExportSession but never sets a videoComposition, so AVFoundation takes the passthrough path and copies the source's compressed samples verbatim. When the requested start does not land on a sync sample, the output's opening frames reference a keyframe that is not in the file, and its first sync sample sits wherever the next source keyframe fell.

The result decodes correctly front to back, which makes the damage easy to miss, but it cannot be seeked back to its own start - players snap forward to that first sync sample instead. A looping player shows only the tail of the clip.

Measured on a 30fps H.264 capture with a 2 second GOP, trimmed to 6.166-9.333s: the 3.167s output reported start_time 0 and a full frame count, but carried exactly one sync sample, at 1.834s, and opened on B and P frames. AVPlayer looped it 1.83s to 3.17s forever. With a videoComposition the same trim yields sync samples at 0.000, 0.935, 1.902 and 2.869, at unchanged 538x960.

Guarded on the asset having a video track, since trimVideo accepts audio-only assets and AVVideoComposition(propertiesOf:) has nothing to size itself from there.